### PR TITLE
Add optional UserData fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,27 @@
+# Composer
+composer.phar
+/vendor/
+
+# Commit your application's lock file https://getcomposer.org/doc/01-basic-usage.md#commit-your-composer-lock-file-to-version-control
+# You may choose to ignore a library lock file http://getcomposer.org/doc/02-libraries.md#lock-file
+composer.lock
+
+# PHPUnit
+/.ant_targets
+/.idea
+/.php_cs
+/.php_cs.cache
+/.phpunit.result.cache
+/build/documentation
+/build/logfiles
+/build/phar
+/build/phpdox
+/build/*.phar
+/build/*.phar.asc
+/build/binary-phar-autoload.php
+/cache.properties
+/tests/TextUI/*.diff
+/tests/TextUI/*.exp
+/tests/TextUI/*.log
+/tests/TextUI/*.out
+/tests/TextUI/*.php

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,11 @@
     "license": "MIT",
     "minimum-stability": "dev",
     "require": {
+        "php": "^5.6 || ^7.0",
         "guzzlehttp/guzzle": "^6.2"
+    },
+    "require-dev": {
+        "phpunit/phpunit": ">=5.7.27"
     },
     "authors": [
         {
@@ -20,5 +24,16 @@
         "psr-4": {
             "Pelecard\\": "src/Pelecard"
         }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Pelecard\\": "test/Pelecard"
+        }
+    },
+    "scripts": {
+        "test": [
+            "@phpunit"
+        ],
+        "phpunit": "phpunit --whitelist src ./test"
     }
 }

--- a/src/Pelecard/PaymentRequest.php
+++ b/src/Pelecard/PaymentRequest.php
@@ -88,6 +88,9 @@ class PaymentRequest implements \JsonSerializable {
   // Custom field captions
   protected $CaptionSet;
 
+  // UserData. Free text fields. These fields are not sent to SHVA. These fields return with transaction details
+  protected $UserData;
+
   /**
    * Payment constructor.
    *
@@ -198,6 +201,26 @@ class PaymentRequest implements \JsonSerializable {
    */
   public function enableTestMode($enable) {
     $this->AuthNum = $enable ? '1234567' : NULL;
+  }
+
+  /**
+   * Sets UserData which described as "Free text fields" in manual.
+   * These fields are not sent to SHVA.
+   * These fields return with transaction details.
+   *
+   * @param string $fieldName User field name. Possible values are UserData1, UserData2, ...UserData15
+   * @param string $data      Data itself
+   * @throws \InvalidArgumentException
+   */
+  public function setUserData($fieldName, $data) {
+    if (!is_string($fieldName) || preg_match("/^UserData([1-9]|1[0-5])$/", $fieldName) !== 1) {
+      throw new \InvalidArgumentException('Invalid `$fieldName`. Keys UserData1, UserData2, ...UserData15 are allowed');
+    }
+    if (!is_string($data) && $data !== null) {
+      throw new \InvalidArgumentException('Invalid `$data`. Data must be string or `null` when you need to unset it');
+    }
+    if (!is_array($this->UserData)) $this->UserData = [];
+    $this->UserData[$fieldName] = $data;
   }
 
   /**

--- a/src/Pelecard/PelecardTransaction.php
+++ b/src/Pelecard/PelecardTransaction.php
@@ -29,6 +29,7 @@ class PelecardTransaction {
   private $CardHolderID; // OwnerIdNum
   private $FirstPaymentTotal;
   private $FixedPaymentTotal;
+  private $UserData; // UserData
 
   /**
    * PelecardTransaction constructor.
@@ -50,6 +51,9 @@ class PelecardTransaction {
     if (!empty($transaction_result->ResultData)) {
       $this->extractPropertiesFromResponse($transaction_result->ResultData);
     }
+    if (!empty($transaction_result->UserData)) {
+      $this->extractFieldsFromUserData($transaction_result->UserData);
+    }
   }
 
   /**
@@ -65,6 +69,17 @@ class PelecardTransaction {
       if (isset($response->{$property_name})) {
         $this->{$property_name} = $response->{$property_name};
       }
+    }
+  }
+
+  /**
+   * Helper function to extract user fields from the transaction UserData.
+   * @param $userData
+   */
+  private function extractFieldsFromUserData($userData) {
+    $this->UserData = [];
+    foreach($userData as $fieldName => $data) {
+      $this->UserData[$fieldName] = $data;
     }
   }
 
@@ -183,6 +198,14 @@ class PelecardTransaction {
     ];
 
     return $map[$num];
+  }
+
+  /**
+   * Returns UserData if it has been specified in PaymentRequest
+   * @return array|null
+   */
+  public function getUserData() {
+    return $this->UserData;
   }
 
 }

--- a/test/Pelecard/PaymentRequestTest.php
+++ b/test/Pelecard/PaymentRequestTest.php
@@ -1,0 +1,175 @@
+<?php
+/**
+ * @file PaymentRequestTest class - tests PaymentRequest class.
+ */
+namespace Pelecard;
+
+use PHPUnit\Framework\TestCase;
+use Pelecard\PaymentRequest;
+
+class PaymentRequestTest extends TestCase {
+
+  /**
+   * Tests setUserData method with wrong $fieldName arguments
+   *
+   * @dataProvider provideWrongUserDataFieldName
+   * @expectedException InvalidArgumentException
+   * @expectedExceptionMessage Invalid `$fieldName`. Keys UserData1, UserData2, ...UserData15 are allowed
+   * @covers Pelecard\PaymentRequest::setUserData
+   */
+  public function testSetUserDataWithWrongFieldNames($fieldName) {
+    $req = new PaymentRequest('0123456','user','qwerty','http://hostname/good.php',100);
+    // fill out other UserData fields to trace any change
+    for($i=1; $i<16; $i++) {
+      $req->setUserData("UserData{$i}", "test{$i}");
+    }
+    $beforeReqJson = $req->jsonSerialize();
+    if (is_scalar($fieldName)) {
+      $req->setUserData($fieldName, "test{$fieldName}");
+    } elseif ($fieldName instanceof \JsonSerializable) {
+      $req->setUserData($fieldName, "test{json_encode($fieldName)}");
+    } elseif ($fieldName instanceof \Serializable) {
+      $req->setUserData($fieldName, "test{$fieldName->serialize()}");
+    } else {
+      $req->setUserData($fieldName, "testNotSerializable");
+    }
+    $afterReqJson = $req->jsonSerialize();
+    // request shouldn't be changed after wrong value assign
+    $this->assertJsonStringEqualsJsonString(json_encode($beforeReqJson), json_encode($afterReqJson));
+  }
+
+  /**
+   * Tests setUserData method with correct $fieldName arguments
+   *
+   * @dataProvider provideCorrectUserDataFieldName
+   * @covers Pelecard\PaymentRequest::setUserData
+   */
+  public function testSetUserDataWithCorrectFieldNames($fieldName) {
+    $req = new PaymentRequest('0123456','user','qwerty','http://hostname/good.php',100);
+    // fill out other UserData fields to trace any change
+    for($i=1; $i<16; $i++) {
+      $req->setUserData("UserData{$i}", "test{$i}");
+    }
+    $beforeReqJson = $req->jsonSerialize();
+    $req->setUserData($fieldName, "test{$fieldName}");
+    $afterReqJson = $req->jsonSerialize();
+    // updated field should be different
+    $this->assertNotSame($beforeReqJson['UserData'][$fieldName], $afterReqJson['UserData'][$fieldName]);
+    // now update field in old object and compare entire JSON again
+    $beforeReqJson['UserData'][$fieldName] = "test{$fieldName}";
+    $this->assertJsonStringEqualsJsonString(json_encode($beforeReqJson), json_encode($afterReqJson));
+  }
+
+  /**
+   * Tests setUserData method with wrong $data arguments
+   *
+   * @dataProvider provideWrongUserData
+   * @expectedException InvalidArgumentException
+   * @expectedExceptionMessage Invalid `$data`. Data must be string or `null` when you need to unset it
+   * @covers Pelecard\PaymentRequest::setUserData
+   */
+  public function testSetUserDataWithWrongData($data) {
+    $req = new PaymentRequest('0123456','user','qwerty','http://hostname/good.php',100);
+    // fill out other UserData fields to trace any change
+    for($i=1; $i<16; $i++) {
+      $req->setUserData("UserData{$i}", "test{$i}");
+    }
+    $beforeReqJson = $req->jsonSerialize();
+    $req->setUserData('UserData1', $data);
+    $afterReqJson = $req->jsonSerialize();
+    // request shouldn't be changed after wrong value assign
+    $this->assertJsonStringEqualsJsonString(json_encode($beforeReqJson), json_encode($afterReqJson));
+  }
+
+  /**
+   * Tests setUserData method with correct $data arguments
+   *
+   * @dataProvider provideCorrectUserData
+   * @covers Pelecard\PaymentRequest::setUserData
+   */
+  public function testSetUserDataWithCorrectData($data) {
+    $req = new PaymentRequest('0123456','user','qwerty','http://hostname/good.php',100);
+    // fill out other UserData fields to trace any change
+    for($i=1; $i<16; $i++) {
+      $req->setUserData("UserData{$i}", "test{$i}");
+    }
+    $beforeReqJson = $req->jsonSerialize();
+    $req->setUserData('UserData1', $data);
+    $afterReqJson = $req->jsonSerialize();
+    // updated field should be different
+    $this->assertNotSame($beforeReqJson['UserData']['UserData1'], $afterReqJson['UserData']['UserData1']);
+    // now update field in old object and compare entire JSON again
+    $beforeReqJson['UserData']['UserData1'] = $data;
+    $this->assertJsonStringEqualsJsonString(json_encode($beforeReqJson), json_encode($afterReqJson));
+  }
+
+  public function provideWrongUserDataFieldName() {
+    return [
+      [null],
+      [1],
+      ['foo'],
+      ['bar'],
+      [[]],
+      [new \DateTime()],
+      [new \StdClass()],
+      ['userdata1'],
+      ['USERDATA1'],
+      ['USERDATA1'],
+      ['UserData2018'],
+      ['PUserData1'],
+      ['PUserData1P'],
+      ['UserData0'],
+      ['UserData01'],
+      ['UserData16'],
+      ['UserData21'],
+      ['UserData26'],
+    ];
+  }
+
+  public function provideCorrectUserDataFieldName() {
+    return [
+      ['UserData1'],
+      ['UserData2'],
+      ['UserData3'],
+      ['UserData4'],
+      ['UserData5'],
+      ['UserData6'],
+      ['UserData7'],
+      ['UserData8'],
+      ['UserData9'],
+      ['UserData10'],
+      ['UserData11'],
+      ['UserData12'],
+      ['UserData13'],
+      ['UserData14'],
+      ['UserData15'],
+    ];
+  }
+
+  public function provideWrongUserData() {
+    return [
+      [false],
+      [true],
+      [0],
+      [1],
+      [3.14],
+      [-3.14],
+      [new \DateTime()],
+      [new \StdClass()],
+      [[]],
+      [['user', 'john', 'invoice', '00001']],
+      [['user' => 'john', 'invoice' => '00001']],
+    ];
+  }
+
+  public function provideCorrectUserData() {
+    return [
+      [null],
+      ['LoremIpsumDolor'],
+      ['invoice00001'],
+      ['?user=john&invoice_no=00001'],
+      ['{"user":"john","invoice":"00001"}'],
+    ];
+  }
+
+}


### PR DESCRIPTION
Hi, @reissr and other maintainers!

I've implemented `UserData` optional fields from Pelecard manual.
My created method is fully covered with unit tests.
I also checked it manually few times.

## Description from manual
|   Parameter  |       Description       |
|---------------|----------------------|
|  UserData1   |   |
|  UserData2   |   |
|  UserData3   |   |
|  UserData4   |   |
|  UserData5   |   |
|  UserData6   |   |
|  UserData7   | **Free text fields.**   |
|  UserData8   |  These fields are not sent to SHVA.  |
|  UserData9   |  These fields return with transaction details.  |
|  UserData10  |   |
|  UserData11  |   |
|  UserData12  |   |
|  UserData13  |   |
|  UserData14  |   |
|  UserData15  |   |

## Usage example
```php
$PaymentRequest = new \Pelecard\PaymentRequest(
    $terminal, $user, $password, $GoodURL, $Total
);
$PaymentRequest->setUserData('UserData1', 'HelloWorld!');
$PaymentRequest->setUserData('UserData2', 'foo=bar');
$PaymentRequest->setUserData('UserData3', 'user=john&invoice_id=00001');
```

Please, review my code and merge when possible.