### PR TITLE
Add QAResultStatus optional field

### DIFF
--- a/src/Pelecard/PaymentRequest.php
+++ b/src/Pelecard/PaymentRequest.php
@@ -91,6 +91,9 @@ class PaymentRequest implements \JsonSerializable {
   // UserData. Free text fields. These fields are not sent to SHVA. These fields return with transaction details
   protected $UserData;
 
+  // Allows us to simulate good/error response for transaction
+  protected $QAResultStatus;
+
   /**
    * Payment constructor.
    *
@@ -224,11 +227,34 @@ class PaymentRequest implements \JsonSerializable {
   }
 
   /**
+   * Allows us to simulate good/error response for transaction.
+   * Note: Should never be enabled on production!!
+   *
+   * Example:
+   * To get a success response we will send 000
+   * To get false response we will send the status code we want to simulate
+   *
+   * @param string $QAResultStatus
+   *
+   * @throws \InvalidArgumentException
+   */
+  public function setQAResultStatus($QAResultStatus) {
+    if ($QAResultStatus !== NULL && (!is_string($QAResultStatus) || preg_match("/^\d{3}$/", $QAResultStatus) !== 1)) {
+      throw new \InvalidArgumentException('Invalid `$QAResultStatus`. Data must be three-digit status code, eg \'000\' or `null` when you need to unset it');
+    }
+    $this->QAResultStatus = $QAResultStatus;
+  }
+
+  /**
    * Return JSON serialized data
    * @return array
    */
   public function jsonSerialize() {
-    return get_object_vars($this);
+    $serialized = get_object_vars($this);
+    if ($serialized['QAResultStatus'] === NULL) {
+      unset($serialized['QAResultStatus']);
+    }
+    return $serialized;
   }
 
 }

--- a/test/Pelecard/PaymentRequestTest.php
+++ b/test/Pelecard/PaymentRequestTest.php
@@ -103,6 +103,41 @@ class PaymentRequestTest extends TestCase {
     $this->assertJsonStringEqualsJsonString(json_encode($beforeReqJson), json_encode($afterReqJson));
   }
 
+  /**
+   * Tests QAResultStatus property with wrong $value
+   *
+   * @dataProvider provideWrongQAResultStatus
+   * @expectedException InvalidArgumentException
+   * @expectedExceptionMessage Invalid `$QAResultStatus`. Data must be three-digit status code, eg '000' or `null` when you need to unset it
+   * @covers Pelecard\PaymentRequest::setQAResultStatus
+   */
+  public function testQAStatusCodePropertyWithWrongValue($value) {
+    $req = new PaymentRequest('0123456','user','qwerty','http://hostname/good.php',100);
+    $req->setQAResultStatus($value);
+  }
+
+  /**
+   * Tests QAResultStatus property with correct $value
+   *
+   * @dataProvider provideCorrectQAResultStatus
+   * @covers Pelecard\PaymentRequest::setQAResultStatus
+   * @covers Pelecard\PaymentRequest::jsonSerialize
+   */
+  public function testQAResultStatusPropertyWithCorrectValue($value) {
+    $req = new PaymentRequest('0123456','user','qwerty','http://hostname/good.php',100);
+    $req->setQAResultStatus($value);
+
+    $reqJson = $req->jsonSerialize();
+    if ($value === null || $value === NULL) {
+      // need to check that value and key has been removed
+      $this->assertArrayNotHasKey('QAResultStatus', $reqJson);
+      return;
+    }
+
+    $this->assertArrayHasKey('QAResultStatus', $reqJson);
+    $this->assertEquals($value, $reqJson['QAResultStatus']);
+  }
+
   public function provideWrongUserDataFieldName() {
     return [
       [null],
@@ -169,6 +204,59 @@ class PaymentRequestTest extends TestCase {
       ['invoice00001'],
       ['?user=john&invoice_no=00001'],
       ['{"user":"john","invoice":"00001"}'],
+    ];
+  }
+
+  public function provideWrongQAResultStatus() {
+    return [
+      [false],
+      [true],
+      [0],
+      [1],
+      [3.14],
+      [-3.14],
+      [new \DateTime()],
+      [new \StdClass()],
+      [[]],
+      [000],
+      ['0000'],
+      ['00'],
+      ['statuscode'],
+    ];
+  }
+
+  public function provideCorrectQAResultStatus() {
+    return [
+      [null],
+      [NULL],
+      ['000'],
+      ['001'], ['002'], ['003'], ['004'], ['005'], ['006'], ['007'], ['008'], ['009'],
+      ['010'], ['011'], ['012'], ['013'], ['014'], ['015'], ['016'], ['017'], ['018'], ['019'],
+      ['020'], ['021'], ['022'], ['023'], ['024'], ['025'], ['026'], ['027'], ['028'], ['029'],
+      ['030'], ['031'], ['032'], ['033'], ['034'], ['035'], ['036'], ['037'], ['038'], ['039'],
+      ['040'], ['041'], ['042'], ['043'], ['044'], ['045'], ['046'], ['047'],
+      ['051'], ['052'], ['053'], ['057'], ['058'], ['059'],
+      ['060'], ['061'], ['062'], ['063'], ['064'], ['065'], ['066'], ['067'], ['068'], ['069'],
+      ['070'], ['071'], ['072'], ['073'], ['074'], ['075'], ['076'], ['077'], ['079'],
+      ['080'],
+      ['090'], ['091'], ['092'], ['099'],
+      ['101'], ['106'], ['107'], ['108'], ['109'],
+      ['110'], ['111'], ['112'], ['113'], ['114'], ['115'], ['116'], ['117'], ['118'], ['119'],
+      ['120'], ['121'], ['122'], ['123'], ['124'], ['125'], ['126'], ['127'], ['128'], ['129'],
+      ['130'], ['131'], ['132'], ['133'], ['134'], ['135'], ['136'], ['137'], ['138'], ['139'],
+      ['130'], ['131'], ['132'], ['133'], ['134'], ['135'], ['136'], ['137'], ['138'], ['139'],
+      ['140'], ['141'], ['142'], ['143'], ['144'], ['145'], ['146'], ['147'], ['148'], ['149'],
+      ['150'], ['151'], ['152'], ['153'], ['154'], ['155'], ['156'], ['157'], ['158'], ['159'],
+      ['160'], ['161'], ['162'], ['163'], ['164'], ['165'], ['166'], ['167'], ['168'], ['169'],
+      ['170'], ['171'], ['172'], ['173'], ['174'], ['175'], ['176'], ['177'], ['178'], ['179'],
+      ['180'],
+      ['200'], ['201'], ['205'],
+      ['306'], ['308'],
+      ['404'],
+      ['500'], ['501'], ['502'], ['503'], ['505'], ['506'], ['507'], ['508'], ['509'],
+      ['510'],
+      ['597'], ['598'], ['599'],
+      ['999'],
     ];
   }
 


### PR DESCRIPTION
Quote from official manual:
> ### `QAResultStatus`
> Allows us to simulate good/error response for transaction.
> Example:
> To get a success response we will send 000
> To get false response we will send the status code we want to simulate

### Example
```php
require __DIR__ . '/vendor/autoload.php';

use Pelecard\PaymentRequest;

$req = new PaymentRequest('0123456', 'user', 'qwerty', 'http://hostname/good.php', 100);
// force Pelecard to simulate good response
$req->setQAResultStatus('000');
```

All unit tests passed and simulation checked manually by me.

Closes #7 