### PR TITLE
Add option to override GuzzleHttp\Client config

### DIFF
--- a/src/Pelecard/PelecardHttpRequest.php
+++ b/src/Pelecard/PelecardHttpRequest.php
@@ -20,6 +20,12 @@ class PelecardHttpRequest {
   const REQUEST_TIMEOUT = 10;
 
   /**
+   * @var array|null $clientConfig Client configuration settings.
+   * @see \GuzzleHttp\RequestOptions for a list of available request options.
+   */
+  public static $clientConfig;
+
+  /**
    * Helper function to wrap our POST requests
    * @param string $uri The relative URI
    * @param mixed $data The post data
@@ -28,19 +34,33 @@ class PelecardHttpRequest {
    */
   public static function pelecardPostRequest($uri, $data) {
     // Make the Post call
-    $client = new Client(['base_uri' => self::GATEWAY_BASE_URI]);
+    $client = new Client(self::getConfig());
 
-    $response = $client->post($uri,
-      [
-        'headers' => ['Content-Type' => 'application/json'],
-        'json' => $data,
-        'connect_timeout' => self::CONNECTION_TIMEOUT,
-        'timeout' => self::REQUEST_TIMEOUT
-      ]
-    );
+    $response = $client->post($uri, ['json' => $data]);
 
     //Extract the contents from the response.
     return $response->getBody()->getContents();
+  }
+
+  /**
+   * Returns default GuzzleHttp\Client config merged with user defined.
+   *
+   * @see \GuzzleHttp\RequestOptions for a list of available request options.
+   *
+   * @return array
+   */
+  public static function getConfig() {
+    return array_merge(
+      [
+        'connect_timeout' => self::CONNECTION_TIMEOUT, // default connection timeout
+        'timeout' => self::REQUEST_TIMEOUT, // default request timeout
+      ],
+      (is_array(self::$clientConfig)) ? self::$clientConfig : [], // user config
+      [
+        'base_uri' => self::GATEWAY_BASE_URI, // overwrite base uri
+        'headers' => ['Content-Type' => 'application/json'], // overwrite headers
+      ]
+    );
   }
 
 }

--- a/test/Pelecard/PelecardHttpRequestTest.php
+++ b/test/Pelecard/PelecardHttpRequestTest.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * @file PelecardHttpRequestTest class - tests PelecardHttpRequest class.
+ */
+namespace Pelecard;
+
+use PHPUnit\Framework\TestCase;
+use Pelecard\PelecardHttpRequest;
+
+class PelecardHttpRequestTest extends TestCase {
+
+    /**
+     * Tests getConfig static method with wrong $clientConfig types
+     *
+     * @dataProvider provideWrongConfig
+     * @covers Pelecard\PelecardHttpRequest::getConfig
+     */
+    public function testGetConfigWithWrongConfig($config) {
+        // default config
+        $defaults = [
+            'base_uri' => PelecardHttpRequest::GATEWAY_BASE_URI,
+            'headers' => ['Content-Type' => 'application/json'],
+            'connect_timeout' => PelecardHttpRequest::CONNECTION_TIMEOUT,
+            'timeout' => PelecardHttpRequest::REQUEST_TIMEOUT,
+        ];
+
+        $beforeConfig = PelecardHttpRequest::getConfig();
+        $this->assertJsonStringEqualsJsonString(json_encode($defaults), json_encode($beforeConfig));
+
+        // check that provided config is invalid because not array
+        $this->assertFalse(is_array($config));
+
+        // overwrite config with user values
+        PelecardHttpRequest::$clientConfig = $config;
+        $afterConfig = PelecardHttpRequest::getConfig();
+
+        // check that overwritten config didn't change
+        $this->assertJsonStringEqualsJsonString(json_encode($defaults), json_encode($afterConfig));
+    }
+
+    /**
+     * Tests getConfig static method with correct $clientConfig data
+     *
+     * @dataProvider provideCorrectConfig
+     * @covers Pelecard\PelecardHttpRequest::getConfig
+     */
+    public function testGetConfigWithCorrectConfig($config) {
+        // default config
+        $defaults = [
+            'base_uri' => PelecardHttpRequest::GATEWAY_BASE_URI,
+            'headers' => ['Content-Type' => 'application/json'],
+            'connect_timeout' => PelecardHttpRequest::CONNECTION_TIMEOUT,
+            'timeout' => PelecardHttpRequest::REQUEST_TIMEOUT,
+        ];
+
+        $beforeConfig = PelecardHttpRequest::getConfig();
+        $this->assertJsonStringEqualsJsonString(json_encode($defaults), json_encode($beforeConfig));
+
+        // check that provided config is valid
+        $this->assertTrue(is_array($config));
+
+        // overwrite config with user values
+        PelecardHttpRequest::$clientConfig = $config;
+        $afterConfig = PelecardHttpRequest::getConfig();
+
+        // check that overwritten config did change
+        $this->assertJsonStringNotEqualsJsonString(json_encode($defaults), json_encode($afterConfig));
+
+        // check static values
+        $this->assertArrayHasKey('base_uri', $afterConfig);
+        $this->assertArrayHasKey('headers', $afterConfig);
+        $this->assertEquals(PelecardHttpRequest::GATEWAY_BASE_URI, $afterConfig['base_uri']);
+        $this->assertEquals(['Content-Type' => 'application/json'], $afterConfig['headers']);
+
+        // check user values
+        foreach ($config as $optionName => $optionValue) {
+            if (!in_array($optionName, ['base_uri', 'headers'])) {
+                // value should be overwritten
+                $this->assertArrayHasKey($optionName, $afterConfig);
+                $this->assertEquals($optionValue, $afterConfig[$optionName]);
+            }
+        }
+    }
+
+    public function provideWrongConfig() {
+        return [
+            [null],
+            [1],
+            ['foo'],
+            ['bar'],
+            [new \DateTime()],
+            [new \StdClass()],
+        ];
+    }
+
+    public function provideCorrectConfig() {
+        return [
+            [
+                [
+                    'connect_timeout' => 50,
+                    'timeout' => 50,
+                    'base_uri' => 'newbase/api',
+                    'headers' => ['Content-Type' => 'application/json'],
+                ],
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
Makes possible to override hardcoded timeouts in a way:
```php
require __DIR__ . '/vendor/autoload.php';

use Pelecard\PelecardHttpRequest;

PelecardHttpRequest::$clientConfig = [
    'connect_timeout' => 100,
    'timeout' => 100,
];
```
Also with `handler` option in client config we can mock API requests and cover them with unit tests. Quote from documentation:

> When testing HTTP clients, you often need to simulate specific scenarios like returning a successful response, returning an error, or returning specific responses in a certain order. Because unit tests need to be predictable, easy to bootstrap, and fast, hitting an actual remote API is a test smell.

All unit tests passed and I checked package with sandbox credentials manually.

### Guzzle Documentation
[Request Options](http://docs.guzzlephp.org/en/stable/request-options.html)
[Testing Guzzle Clients](http://docs.guzzlephp.org/en/stable/testing.html)

Closes #6 

